### PR TITLE
Add option to get issues for watched repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Flags:
   --interval         update interval (ex. 5ms, 10s, 1m, 3h) (default: 1m0s)
   --once             run once and exit, do not run as a daemon (default: false)
   --orgs             organizations to include (this option only applies to --autofill) (default: [])
+  --watch-since      defines the starting point of the issues been watched (format: 2006-01-02T15:04:05Z). defaults to no filter (default: 2008-01-01T00:00:00Z)
+  --watched          include the watched repositories (default: false)
 
 Commands:
 
@@ -93,7 +95,8 @@ Your airtable table must have the following fields:
 - `updated` **(date, include time)**
 - `created` **(date, include  time)**
 - `completed` **(date, include time)**
-- `project` **(single line text)**
+- `project` **(link to another sheet)**
+- `repository` **(single line text)**
 
 The only data you need to initialize **(if not running with `--autofill`)** 
 is the `Reference` which is in the format

--- a/main.go
+++ b/main.go
@@ -87,19 +87,19 @@ func main() {
 		}
 
 		if len(githubToken) < 1 {
-			return errors.New("GitHub token cannot be empty")
+			return errors.New("gitHub token cannot be empty")
 		}
 
 		if len(airtableAPIKey) < 1 {
-			return errors.New("Airtable API Key cannot be empty")
+			return errors.New("airtable API Key cannot be empty")
 		}
 
 		if len(airtableBaseID) < 1 {
-			return errors.New("Airtable Base ID cannot be empty")
+			return errors.New("airtable Base ID cannot be empty")
 		}
 
 		if len(airtableTableName) < 1 {
-			return errors.New("Airtable Table cannot be empty")
+			return errors.New("airtable Table cannot be empty")
 		}
 
 		return nil

--- a/main.go
+++ b/main.go
@@ -248,9 +248,6 @@ func (bot *bot) run(ctx context.Context, affiliation string) error {
 		page := 1
 		perPage := 100
 		logrus.Info("getting repositories watched...")
-		if err != nil {
-			return err
-		}
 
 		if err := bot.getWatchedRepositories(ctx, page, perPage, since); err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -195,18 +195,19 @@ type githubRecord struct {
 
 // Fields defines the airtable fields for the data.
 type Fields struct {
-	Reference string
-	Title     string
-	State     string
-	Author    string
-	Type      string
-	Labels    []string
-	Comments  int
-	URL       string
-	Updated   time.Time
-	Created   time.Time
-	Completed time.Time
-	Project   interface{}
+	Reference  string
+	Title      string
+	State      string
+	Author     string
+	Type       string
+	Labels     []string
+	Comments   int
+	URL        string
+	Updated    time.Time
+	Created    time.Time
+	Completed  time.Time
+	Project    interface{}
+	Repository string
 }
 
 func (bot *bot) run(ctx context.Context, affiliation string) error {
@@ -315,31 +316,33 @@ func (bot *bot) applyRecordToTable(ctx context.Context, issue *github.Issue, key
 	record := githubRecord{
 		ID: id,
 		Fields: Fields{
-			Reference: key,
-			Title:     issue.GetTitle(),
-			State:     issue.GetState(),
-			Author:    issue.GetUser().GetLogin(),
-			Type:      issueType,
-			Comments:  issue.GetComments(),
-			URL:       issue.GetHTMLURL(),
-			Updated:   issue.GetUpdatedAt(),
-			Created:   issue.GetCreatedAt(),
-			Completed: issue.GetClosedAt(),
+			Reference:  key,
+			Title:      issue.GetTitle(),
+			State:      issue.GetState(),
+			Author:     issue.GetUser().GetLogin(),
+			Type:       issueType,
+			Comments:   issue.GetComments(),
+			URL:        issue.GetHTMLURL(),
+			Updated:    issue.GetUpdatedAt(),
+			Created:    issue.GetCreatedAt(),
+			Completed:  issue.GetClosedAt(),
+			Repository: repo,
 		},
 	}
 
 	// Update the record fields.
 	fields := map[string]interface{}{
-		"Reference": record.Fields.Reference,
-		"Title":     record.Fields.Title,
-		"State":     record.Fields.State,
-		"Author":    record.Fields.Author,
-		"Type":      record.Fields.Type,
-		"Comments":  record.Fields.Comments,
-		"URL":       record.Fields.URL,
-		"Updated":   record.Fields.Updated,
-		"Created":   record.Fields.Created,
-		"Completed": record.Fields.Completed,
+		"Reference":  record.Fields.Reference,
+		"Title":      record.Fields.Title,
+		"State":      record.Fields.State,
+		"Author":     record.Fields.Author,
+		"Type":       record.Fields.Type,
+		"Comments":   record.Fields.Comments,
+		"URL":        record.Fields.URL,
+		"Updated":    record.Fields.Updated,
+		"Created":    record.Fields.Created,
+		"Completed":  record.Fields.Completed,
+		"Repository": record.Fields.Repository,
 	}
 
 	if id != "" {


### PR DESCRIPTION
There are two changes in this pull request.

_First_: Add a **Repository** field so it became better to group in airtable (image attached).

_Second_: Add **-watched** and **-watch-since** flags. The **watched** flag will get issues from repositories you are watching and **watch-since** defines a period for starting getting the issues but if not defined will get every issue (I set the value to 2008-01-01T00:00:00Z). 

Why did I add this?
I watch a few repositories with the intention to contribute in the future, so I wanted a way to keep track of the issues and be able to use the airtable magic to group, filter, and order everything.

![airtable-with-repository](https://user-images.githubusercontent.com/58203/41378537-b364e046-6f35-11e8-9f32-6bc9f6dac0cf.png)

ps: awesome project 🥇 
 