### PR TITLE
handles bad GH data more gracefully

### DIFF
--- a/main.go
+++ b/main.go
@@ -326,6 +326,7 @@ func (bot *bot) applyRecordToTable(ctx context.Context, issue *github.Issue, key
 			Updated:   issue.GetUpdatedAt(),
 			Created:   issue.GetCreatedAt(),
 			Completed: issue.GetClosedAt(),
+			Project:   repo,
 		},
 	}
 
@@ -341,6 +342,7 @@ func (bot *bot) applyRecordToTable(ctx context.Context, issue *github.Issue, key
 		"Updated":   record.Fields.Updated,
 		"Created":   record.Fields.Created,
 		"Completed": record.Fields.Completed,
+		"Project":   record.Fields.Project,
 	}
 
 	if id != "" {


### PR DESCRIPTION
For some unknown reasons, I got some data back from GH that the bot couldn't parse. Instead of stopping the entire import, this change prints an error but keeps on going since there isn't much the user can do.

This is a bit of an opinionated change based on my own needs/import, it might be a me-only issue due to my weird GitHub data :)