### PR TITLE
Updated link to airtable guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Commands:
 
 #### Using the API
 
-[Follow this guide](http://help.grow.com/connecting-your-data-internal-and-project-management/airtable/airtable-how-to-connect).
+[Follow this guide](https://help.grow.com/hc/en-us/articles/360015095834-Airtable).
 
 #### Format
 


### PR DESCRIPTION
The link to the grow.com API connection guide seems to be broken. Hope this is the correct updated link.